### PR TITLE
Use `String#scan` in order to extract multiple mentions

### DIFF
--- a/app/models/webhooks/from/base.rb
+++ b/app/models/webhooks/from/base.rb
@@ -19,7 +19,7 @@ class Webhooks::From::Base
 
   def mentions
     return [] unless comment
-    comment.match(/@([\S]+)/).to_a[1..-1] || []
+    comment.scan(/@([\S]+)/).flatten || []
   end
 
   def additional_message


### PR DESCRIPTION
Only first mention
```
2.2.4 (main)> 'cc @ppworks @nalabjp @aaa @bbb @ccc'.match(/@([\S]+)/).to_a[1..-1]                                                       
[
    [0] "ppworks"
]
```

Multiple mentions
```
2.2.4 (main)> 'cc @ppworks @nalabjp @aaa @bbb @ccc'.scan(/@([\S]+)/).flatten
[
    [0] "ppworks",
    [1] "nalabjp",
    [2] "aaa",
    [3] "bbb",
    [4] "ccc"
]
```