### PR TITLE
customize integration github <-> slack 

### DIFF
--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -36,20 +36,14 @@ class Webhook < ApplicationRecord
 
   def run(payload:)
     from_instance = from_class.new(payload: payload)
-    puts "run1"
     return unless from_instance.accept?
 
-    puts "run2 #{from_instance}"
     mentions = from_instance.mentions.map { |m|
       id_mapping ||= IdMapping.new(ENV.fetch('MENTIONS_MAPPING_FILE_PATH'))
-      puts "run2.5 #{m}"
       id_mapping.find(user_name: m, from: from, to: to)
     }.compact
 
-
-    puts "run3 #{mentions}"
-
-    mentions.each do |mention|
+    mentions.uniq.each do |mention|
       to_class.new(mention: mention, from: from_instance.from, id: from_instance.id, icon_url: from_instance.icon_url, summary: from_instance.summary, title: from_instance.title, url: from_instance.url, body: from_instance.body).post
     end
   end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -50,7 +50,7 @@ class Webhook < ApplicationRecord
     puts "run3 #{mentions}"
 
     mentions.each do |mention|
-      to_class.new(mention: mention, from: from_instance.from, icon_url: from_instance.icon_url, summary: from_instance.summary, title: from_instance.title, url: from_instance.url, body: from_instance.body).post
+      to_class.new(mention: mention, from: from_instance.from, id: from_instance.id, icon_url: from_instance.icon_url, summary: from_instance.summary, title: from_instance.title, url: from_instance.url, body: from_instance.body).post
     end
   end
 

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -36,15 +36,21 @@ class Webhook < ApplicationRecord
 
   def run(payload:)
     from_instance = from_class.new(payload: payload)
+    puts "run1"
     return unless from_instance.accept?
 
+    puts "run2 #{from_instance}"
     mentions = from_instance.mentions.map { |m|
       id_mapping ||= IdMapping.new(ENV.fetch('MENTIONS_MAPPING_FILE_PATH'))
+      puts "run2.5 #{m}"
       id_mapping.find(user_name: m, from: from, to: to)
     }.compact
 
+
+    puts "run3 #{mentions}"
+
     mentions.each do |mention|
-      to_class.new(mention: mention, url: from_instance.url, additional_message: from_instance.additional_message).post
+      to_class.new(mention: mention, from: from_instance.from, icon_url: from_instance.icon_url, summary: from_instance.summary, title: from_instance.title, url: from_instance.url, body: from_instance.body).post
     end
   end
 

--- a/app/models/webhooks/from/base.rb
+++ b/app/models/webhooks/from/base.rb
@@ -13,6 +13,18 @@ class Webhooks::From::Base
     ''
   end
 
+  def from
+    ''
+  end
+
+  def icon_url
+    ''
+  end
+
+  def sender
+    ''
+  end
+
   def title
     ''
   end
@@ -21,12 +33,16 @@ class Webhooks::From::Base
     ''
   end
 
+  def body
+    ''
+  end
+
   def mentions
     return [] unless comment
     comment.scan(/@([\S]+)/).flatten || []
   end
 
-  def additional_message
+  def summary
     "you've been mentioned"
   end
 

--- a/app/models/webhooks/from/base.rb
+++ b/app/models/webhooks/from/base.rb
@@ -13,6 +13,10 @@ class Webhooks::From::Base
     ''
   end
 
+  def title
+    ''
+  end
+
   def url
     ''
   end

--- a/app/models/webhooks/from/base.rb
+++ b/app/models/webhooks/from/base.rb
@@ -17,6 +17,10 @@ class Webhooks::From::Base
     ''
   end
 
+  def id
+    ''
+  end
+
   def icon_url
     ''
   end

--- a/app/models/webhooks/from/esa.rb
+++ b/app/models/webhooks/from/esa.rb
@@ -14,7 +14,7 @@ class Webhooks::From::Esa < Webhooks::From::Base
     [@payload.dig('mentioned_user', 'screen_name')].compact
   end
 
-  def additional_message
+  def summary
     "you've been mentioned(\\( ⁰⊖⁰)/)"
   end
 end

--- a/app/models/webhooks/from/github.rb
+++ b/app/models/webhooks/from/github.rb
@@ -1,6 +1,6 @@
 class Webhooks::From::Github < Webhooks::From::Base
   PATTERNS = %w(comment pull_request issue)
-  ACCEPT_ACTIONS = %w(created opened assigned)
+  ACCEPT_ACTIONS = %w(created opened assigned edited)
 
   def comment
     assigned? ? 'assigned' : search_content('body')
@@ -11,7 +11,7 @@ class Webhooks::From::Github < Webhooks::From::Base
   end
 
   def id
-    assigned? ? [@payload.dig('pull_request', 'number')].compact.first : [@payload.dig('issue', 'number')].compact.first
+    opened? ? [@payload.dig('pull_request', 'number')].compact.first : [@payload.dig('issue', 'number')].compact.first
   end
 
   def icon_url
@@ -22,8 +22,12 @@ class Webhooks::From::Github < Webhooks::From::Base
     [@payload.dig('sender', 'login')].compact.first
   end
 
+  def action
+    @payload['action']
+  end
+
   def summary
-    assigned? ? "you've been assigned by #{sender}" : "you've been mentioned from #{sender}"
+    "you've been mention by #{action} from #{sender}"
   end
 
   def title
@@ -50,7 +54,11 @@ class Webhooks::From::Github < Webhooks::From::Base
     @payload.dig('action') == 'assigned'
   end
 
+  def opened?
+    @payload.dig('action') == 'opened'
+  end
+
   def accept?
-    ACCEPT_ACTIONS.include?(@payload['action'])
+    ACCEPT_ACTIONS.include?(action)
   end
 end

--- a/app/models/webhooks/from/github.rb
+++ b/app/models/webhooks/from/github.rb
@@ -6,6 +6,26 @@ class Webhooks::From::Github < Webhooks::From::Base
     assigned? ? 'assigned' : search_content('body')
   end
 
+  def from
+    "#{sender}@github"
+  end
+
+  def icon_url
+    [@payload.dig('sender', 'avatar_url')].compact.first
+  end
+
+  def sender
+    [@payload.dig('sender', 'login')].compact.first
+  end
+
+  def summary
+    assigned? ? "you've been assigned by #{sender}" : "you've been mentioned from #{sender}"
+  end
+
+  def title
+    search_content('title')
+  end
+
   def url
     search_content('html_url')
   end
@@ -18,12 +38,12 @@ class Webhooks::From::Github < Webhooks::From::Base
     end
   end
 
-  def assigned?
-    @payload.dig('action') == 'assigned'
+  def body
+    assigned? ? nil : search_content('body')
   end
 
-  def additional_message
-    assigned? ? "you've been assigned" : super
+  def assigned?
+    @payload.dig('action') == 'assigned'
   end
 
   def accept?

--- a/app/models/webhooks/from/github.rb
+++ b/app/models/webhooks/from/github.rb
@@ -27,7 +27,8 @@ class Webhooks::From::Github < Webhooks::From::Base
   end
 
   def summary
-    "you've been mention by #{action} from #{sender}"
+    msg_action = assigned? ? 'assigned' : "mention"
+    "you've been #{msg_action} from #{sender}"
   end
 
   def title

--- a/app/models/webhooks/from/github.rb
+++ b/app/models/webhooks/from/github.rb
@@ -30,16 +30,16 @@ class Webhooks::From::Github < Webhooks::From::Base
     search_content('html_url')
   end
 
+  def body
+    assigned? ? nil : search_content('body')
+  end
+
   def mentions
     if assigned?
       [@payload.dig('assignee', 'login')].compact
     else
       super
     end
-  end
-
-  def body
-    assigned? ? nil : search_content('body')
   end
 
   def assigned?

--- a/app/models/webhooks/from/github.rb
+++ b/app/models/webhooks/from/github.rb
@@ -10,6 +10,10 @@ class Webhooks::From::Github < Webhooks::From::Base
     "#{sender}@github"
   end
 
+  def id
+    assigned? ? [@payload.dig('pull_request', 'number')].compact.first : [@payload.dig('issue', 'number')].compact.first
+  end
+
   def icon_url
     [@payload.dig('sender', 'avatar_url')].compact.first
   end

--- a/app/models/webhooks/to/idobata.rb
+++ b/app/models/webhooks/to/idobata.rb
@@ -1,5 +1,5 @@
 class Webhooks::To::Idobata
-  def initialize(mention:, from:, icon_url:, summary:, title:, url:, body:)
+  def initialize(mention:, from:, id:, icon_url:, summary:, title:, url:, body:)
     @mention = "@#{mention}"
     @text = "#{@mention} #{url} #{summary}"
     # TODO: support multiple hook

--- a/app/models/webhooks/to/idobata.rb
+++ b/app/models/webhooks/to/idobata.rb
@@ -1,5 +1,5 @@
 class Webhooks::To::Idobata
-  def initialize(mention:, url:, additional_message:)
+  def initialize(mention:, title:, url:, additional_message:)
     @mention = "@#{mention}"
     @text = "#{@mention} #{url} #{additional_message}"
     # TODO: support multiple hook

--- a/app/models/webhooks/to/idobata.rb
+++ b/app/models/webhooks/to/idobata.rb
@@ -1,7 +1,7 @@
 class Webhooks::To::Idobata
-  def initialize(mention:, title:, url:, additional_message:)
+  def initialize(mention:, from:, icon_url:, summary:, title:, url:, body:)
     @mention = "@#{mention}"
-    @text = "#{@mention} #{url} #{additional_message}"
+    @text = "#{@mention} #{url} #{summary}"
     # TODO: support multiple hook
     @webhook_uri = ENV.fetch('IDOBATA_WEBHOOK_URL')
   end

--- a/app/models/webhooks/to/slack.rb
+++ b/app/models/webhooks/to/slack.rb
@@ -28,7 +28,7 @@ class Webhooks::To::Slack
         link_names: 1,
         channel: @channel
     }
-    puts payload
+    puts payload.to_json
     HttpPostJob.perform_later(@webhook_uri, { payload: payload.to_json })
   end
 end

--- a/app/models/webhooks/to/slack.rb
+++ b/app/models/webhooks/to/slack.rb
@@ -1,9 +1,9 @@
 class Webhooks::To::Slack
-  def initialize(mention:, from:, icon_url:, summary:, title:, url:, body:)
+  def initialize(mention:, from:, id:, icon_url:, summary:, title:, url:, body:)
     @mention = "@#{mention}"
     @channel = @mention == '@everyone' ? '#general' : @mention
     @from = from
-    @summary = summary
+    @summary = "<#{url}|#{id}>: #{summary}"
     @title = title
     @url = url
     @icon_url = icon_url

--- a/app/models/webhooks/to/slack.rb
+++ b/app/models/webhooks/to/slack.rb
@@ -1,12 +1,34 @@
 class Webhooks::To::Slack
-  def initialize(mention:, url:, additional_message:)
+  def initialize(mention:, from:, icon_url:, summary:, title:, url:, body:)
     @mention = "@#{mention}"
     @channel = @mention == '@everyone' ? '#general' : @mention
-    @text = "#{@mention} #{url} #{additional_message}"
+    @from = from
+    @summary = summary
+    @title = title
+    @url = url
+    @icon_url = icon_url
+    @body = body
     @webhook_uri = ENV.fetch('SLACK_WEBHOOK_URL')
   end
 
   def post
-    HttpPostJob.perform_later(@webhook_uri, { payload: {text: @text, link_names: 1, channel: @channel}.to_json })
+
+    payload = {
+        username: @from,
+        icon_url: @icon_url,
+        text: @summary,
+        attachments: [
+            {
+                title: @title,
+                title_link: @url,
+                text: @body,
+                mrkdwn_in: ["text"]
+            }
+        ],
+        link_names: 1,
+        channel: @channel
+    }
+    puts payload
+    HttpPostJob.perform_later(@webhook_uri, { payload: payload.to_json })
   end
 end

--- a/app/models/webhooks/to/slack.rb
+++ b/app/models/webhooks/to/slack.rb
@@ -28,7 +28,6 @@ class Webhooks::To::Slack
         link_names: 1,
         channel: @channel
     }
-    puts payload.to_json
     HttpPostJob.perform_later(@webhook_uri, { payload: payload.to_json })
   end
 end

--- a/test/models/webhooks/to/slack_test.rb
+++ b/test/models/webhooks/to/slack_test.rb
@@ -5,10 +5,16 @@ class Webhooks::To::SlackTest < ActiveSupport::TestCase
 
   def test_run
     mention = 'ppworks'
+    from = 'johndoe'
+    id = '1'
+    icon_url = 'http://icon.example.com'
     url = 'http://example.com'
-    additional_message = 'message'
+    summary = 'summary'
+    title = 'title'
+    body = 'message'
 
-    slack = Webhooks::To::Slack.new(mention: mention, url: url, additional_message: additional_message)
+    slack = Webhooks::To::Slack.new(mention: mention, from: from, id:id, icon_url:icon_url, summary:summary, title:title, url: url, body: body)
+
     assert_enqueued_with(job: HttpPostJob) do
       slack.post
     end
@@ -19,10 +25,15 @@ class Webhooks::To::SlackTest < ActiveSupport::TestCase
 
   def test_run_everyone
     mention = 'everyone'
+    from = 'johndoe'
+    id = '1'
+    icon_url = 'http://icon.example.com'
     url = 'http://example.com'
-    additional_message = 'message'
+    summary = 'summary'
+    title = 'title'
+    body = 'message'
 
-    slack = Webhooks::To::Slack.new(mention: mention, url: url, additional_message: additional_message)
+    slack = Webhooks::To::Slack.new(mention: mention, from: from, id:id, icon_url:icon_url, summary:summary, title:title, url: url, body: body)
     assert_enqueued_with(job: HttpPostJob) do
       slack.post
     end


### PR DESCRIPTION
- 編集時も通知が来るようにしました。
- githubのアイコンを参照するようにしました。
- slackのメッセージフォーマット用に色々パラメータ追加（mentionされたメッセージを通知に含めるようにしたりしました。
- 1msgにmention対象が複数ある時に重複して通知が来ないようにしました。

![image](https://cloud.githubusercontent.com/assets/1043276/18979809/35cf0de8-8709-11e6-835d-c609451a0460.png)

---

リファクタリングというより機能追加なので、設計が汚くなっちゃってる感はあります。
せっかくなのでフィードバックとしてPRを作成しておきました。
良ければ取込ください :bow:
