### PR TITLE
[feature request] add title information of github mentions.

### DIFF
--- a/app/models/webhooks/from/github.rb
+++ b/app/models/webhooks/from/github.rb
@@ -38,17 +38,27 @@ class Webhooks::From::Github < Webhooks::From::Base
   end
 
   def additional_message
+    title ? "*#{title}* #{base_message}" : base_message
+  end
+
+  def accept?
+    ACCEPT_ACTIONS.include?(@payload['action'])
+  end
+
+  private
+
+  def title
+    search_content('title')
+  end
+
+  def base_message
     case
     when assigned?
       "you've been assigned"
     when review_requested?
       "you've been review requested"
     else
-      super
+      "you've been mentioned"
     end
-  end
-
-  def accept?
-    ACCEPT_ACTIONS.include?(@payload['action'])
   end
 end

--- a/test/models/webhooks/from/github_test.rb
+++ b/test/models/webhooks/from/github_test.rb
@@ -42,6 +42,33 @@ class Webhooks::From::GithubTest < ActiveSupport::TestCase
     end
   end
 
+  def test_additional_message_of_pull_request
+    %w(pull_request
+      pull_request_review_comment).each do |event|
+      payload = YAML.load_file("#{Rails.root}/test/payloads/github_payloads.yml")[event]['body']
+      github = Webhooks::From::Github.new(payload: payload)
+
+      assert github.additional_message.include?('*Update the README with new information*')
+    end
+  end
+
+  def test_additional_message_of_issue
+    %w(issue_comment
+       issues).each do |event|
+      payload = YAML.load_file("#{Rails.root}/test/payloads/github_payloads.yml")[event]['body']
+      github = Webhooks::From::Github.new(payload: payload)
+
+      assert_equal "*Spelling error in the README file* you've been mentioned", github.additional_message
+    end
+  end
+
+  def test_additional_message_of_commit
+    payload = YAML.load_file("#{Rails.root}/test/payloads/github_payloads.yml")['commit_comment']['body']
+    github = Webhooks::From::Github.new(payload: payload)
+
+    assert_equal "you've been mentioned", github.additional_message
+  end
+
   def test_accept?
     %w(created
        opened


### PR DESCRIPTION
I want to know mention's source PRs. So extend `additional_message` of github. How do you think?