### PR TITLE
returns 500 response when JSON decoding fails

### DIFF
--- a/app/models/webhooks/from/base.rb
+++ b/app/models/webhooks/from/base.rb
@@ -5,8 +5,6 @@ class Webhooks::From::Base
 
   def initialize(payload:)
     @payload = JSON.parse(payload)
-  rescue
-    @payload = {}
   end
 
   def comment

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -9,7 +9,9 @@ class WebhooksControllerTest < ActionController::TestCase
 
   def test_hook_from_github_and_new_by_env
     ENV['GITHUB_TO_SLACK_TOKEN'] = 'env_token'
-    post :create, params: { token: 'env_token' }
+    event = "commit_comment"
+    payload = YAML.load_file("#{Rails.root}/test/payloads/github_payloads.yml")[event]['body']
+    post :create, params: { token: 'env_token' }, body: payload
     assert_response :success
     ENV.delete('GITHUB_TO_SLACK_TOKEN')
   end


### PR DESCRIPTION
Configurable post content types on current GitHub:
- `application/x-www-form-urlencoded` <- **is default on GitHub**
- `application/json` <- **it must be selected on ppworks/mentions**

If `application/x-www-form-urlencoded` selected, json decoding fails.
But 204 (OK) response is returned and the user of this tool can not notice the reason for failure.

The failure reason will be logged by throwing an exception. e.g.:

```bash
$ heroku logs --tail
2018-01-06T18:21:58.485076+00:00 app[web.1]: [d0b09f64-bdb9-4c70-892d-d41e2c0513d5] Completed 500 Internal Server Error in 274ms (ActiveRecord: 59.9ms)
2018-01-06T18:21:58.487369+00:00 app[web.1]: [d0b09f64-bdb9-4c70-892d-d41e2c0513d5]
2018-01-06T18:21:58.487635+00:00 app[web.1]: [d0b09f64-bdb9-4c70-892d-d41e2c0513d5] JSON::ParserError (751: unexpected token at 'payload=%7B%22action%22%3A%22assigned%22%2C...
```