### PR TITLE
an error occurred when importing a yml file in local

### DIFF
--- a/app/jobs/http_post_job.rb
+++ b/app/jobs/http_post_job.rb
@@ -1,5 +1,6 @@
 class HttpPostJob < ApplicationJob
   def perform(uri, params)
+    require 'net/http'
     Net::HTTP.post_form(URI.parse(uri), params)
   end
 end


### PR DESCRIPTION
/config内などに置いたymlファイルを読み込む際に、Net::HTTPが参照できないエラーが発生するので、その点を修正しました。

```
2019-08-28T04:33:14.773739+00:00 app[web.1]: [ActiveJob] [HttpPostJob] [5b1db9ee-883a-471d-bb88-630cb812584d] Error performing HttpPostJob (Job ID: 5b1db9ee-883a-471d-bb88-630cb812584d) from Async(default) in 9.16ms: NameError (uninitialized constant HttpPostJob::Net
```
